### PR TITLE
Version 4.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'java'
     id 'org.spongepowered.plugin' version '0.9.0'
-    id "io.freefair.lombok" version "3.8.4"
+    id "io.freefair.lombok" version "4.1.3"
 }
 
 compileJava.options.encoding = 'UTF-8'
 
 group = 'se.walkercrou'
-version = '4.0.0'
+version = '4.0.1'
 description = 'Note block music importer and player.'
 
 sourceCompatibility = '1.8'

--- a/src/main/java/se/walkercrou/composer/Composer.java
+++ b/src/main/java/se/walkercrou/composer/Composer.java
@@ -2,6 +2,7 @@ package se.walkercrou.composer;
 
 import com.google.inject.Inject;
 import lombok.Getter;
+import lombok.Setter;
 import ninja.leaping.configurate.ConfigurationNode;
 import ninja.leaping.configurate.commented.CommentedConfigurationNode;
 import ninja.leaping.configurate.loader.ConfigurationLoader;
@@ -14,6 +15,7 @@ import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.scheduler.Task;
 import se.walkercrou.composer.cmd.ComposerCommands;
 import se.walkercrou.composer.cmd.TestCommands;
+import se.walkercrou.composer.exception.CorruptedFileException;
 import se.walkercrou.composer.nbs.MusicPlayer;
 import se.walkercrou.composer.nbs.NoteBlockStudioSong;
 
@@ -28,8 +30,10 @@ import java.util.*;
 /**
  * Main class for Composer plugin.
  */
-@Plugin(id = "composer", authors = { "windy" })
+@Plugin(id = "composer", authors = { "windy","sarhatabaot" })
 public class Composer {
+    @Getter @Setter
+    private static Composer instance;
 
     @Inject
     @Getter
@@ -46,6 +50,7 @@ public class Composer {
     @Listener
     public void onGameStarted(GameStartedServerEvent event) {
         setupConfig();
+        setInstance(this);
         if (config.getNode("debugMode").getBoolean())
             new TestCommands(this).register();
         new ComposerCommands(this).register();
@@ -97,7 +102,7 @@ public class Composer {
                     try {
                         nbsTracks.add(NoteBlockStudioSong.read(path.toFile()));
                         progress(++progress / total * 100);
-                    } catch (IOException e) {
+                    } catch (IOException| CorruptedFileException e) {
                         logger.error("Could not read file (file is likely malformed): " + path, e);
                     }
                 }

--- a/src/main/java/se/walkercrou/composer/cmd/TestCommands.java
+++ b/src/main/java/se/walkercrou/composer/cmd/TestCommands.java
@@ -26,6 +26,7 @@ import org.spongepowered.api.entity.living.player.Player;
 import org.spongepowered.api.text.Text;
 import org.spongepowered.api.util.annotation.NonnullByDefault;
 import se.walkercrou.composer.Composer;
+import se.walkercrou.composer.exception.CorruptedFileException;
 import se.walkercrou.composer.score.Measure;
 import se.walkercrou.composer.score.Note;
 import se.walkercrou.composer.score.Score;
@@ -86,7 +87,7 @@ public class TestCommands {
         NoteBlockStudioSong nbs;
         try {
             nbs = NoteBlockStudioSong.read(new File(context.<String>getOne("file").get()));
-        } catch (IOException e) {
+        } catch (IOException| CorruptedFileException e) {
             e.printStackTrace();
             throw new CommandException(Text.of("Error reading NBS file"), e);
         }

--- a/src/main/java/se/walkercrou/composer/exception/CorruptedFileException.java
+++ b/src/main/java/se/walkercrou/composer/exception/CorruptedFileException.java
@@ -1,0 +1,10 @@
+package se.walkercrou.composer.exception;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CorruptedFileException extends Exception {
+	public CorruptedFileException(final String message) {
+		super(message);
+	}
+}


### PR DESCRIPTION
When some files are corrupted they will throw an ArrayIndexOutOfBounds exception.
* Read method will throw a CorruptedFileException and gracefully fail, preventing a crash of the whole plugin.
Fixes #3 